### PR TITLE
Dont clear item

### DIFF
--- a/client/modules/post/reducers/postSingleReducers.js
+++ b/client/modules/post/reducers/postSingleReducers.js
@@ -19,7 +19,7 @@ function single(state = {
     case singleActions.REQUEST_SINGLE_POST:
       return Object.assign({}, state, {
         isFetching: true
-        , item: {}
+        // , item: {}
         , status: null
       })
       break;
@@ -45,7 +45,7 @@ function single(state = {
     case singleActions.REQUEST_SINGLE_POST_BY_SLUG:
       return Object.assign({}, state, {
         isFetching: true
-        , item: {}
+        // , item: {}
         , status: null
       })
       break;
@@ -72,7 +72,7 @@ function single(state = {
     case singleActions.REQUEST_AND_POPULATE_SINGLE_POST:
       return Object.assign({}, state, {
         isFetching: true
-        , item: {}
+        // , item: {}
         , status: null
       })
       break;
@@ -98,7 +98,7 @@ function single(state = {
     case singleActions.REQUEST_AND_POPULATE_SINGLE_POST_BY_SLUG:
       return Object.assign({}, state, {
         isFetching: true
-        , item: {}
+        // , item: {}
         , status: null
       })
       break;

--- a/client/modules/product/reducers/productSingleReducers.js
+++ b/client/modules/product/reducers/productSingleReducers.js
@@ -21,7 +21,7 @@ function single(state = {
     case singleActions.REQUEST_SINGLE_PRODUCT:
       return Object.assign({}, state, {
         isFetching: true
-        , item: {}
+        // , item: {} // when transitioning within states where this is already populate -- i.e. from 'Single' to 'Update', this forces a refresh on the element, which isn't desirable.  Also, retrieve error is handled below, so this shouldn't be necessary even when calling new instances
         , status: null
       })
       break;
@@ -47,7 +47,7 @@ function single(state = {
     case singleActions.REQUEST_AND_POPULATE_SINGLE_PRODUCT:
       return Object.assign({}, state, {
         isFetching: true
-        , item: {}
+        // , item: {} // see above
         , status: null
       })
       break;


### PR DESCRIPTION
When transitioning between states where the resource is already loaded -- i.e. from 'Single' to 'Update' -- returning `item: {}` on the REQUEST_SINGLE_ITEM action forces a refresh on the element. Which isn't desirable.  Also, instance fetch error is handled in RECEIVE_SINGLE_ITEM, so this shouldn't be necessary even when calling new versions of the resource. 
