### PR TITLE
login user and user token stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ each will log to the console normally on dev. when env="production", though, any
 
 using the regular "console.log" is perfectly fine for debugging stuff. for anything that we might want to keep track of, use "logger.info".
 
-
+LOAD BALANCING
 Additional notes on production deployment
   - 2 load balanced web server instances and a separate database instance
 
@@ -345,3 +345,6 @@ TODO: notes on instance creation and auto-deploying containers during instance c
 https://cloud.google.com/compute/docs/containers/container_vms
 
 
+NEW TYPE OF CONTAINERS - the "container optimized" ones are now obsolete, so going forward we will use the new gci ones
+notes - does not require sudo before commands, diff colors and filesystems
+https://cloud.google.com/container-optimized-os/docs/how-to/create-configure-instance

--- a/yote.js
+++ b/yote.js
@@ -123,7 +123,7 @@ app.use(function(req, res, next) {
 passport.use('local', new LocalStrategy(
   function(username, password, done) {
     var projection = {
-      firstName: 1, lastName: 1, username: 1, password_salt: 1, password_hash: 1, roles: 1
+      username: 1, password_salt: 1, password_hash: 1, roles: 1
     }
     User.findOne({username:username}, projection).exec(function(err, user) {
       if(user && user.authenticate(password)) {
@@ -146,7 +146,7 @@ passport.serializeUser(function(user, done) {
 
 passport.deserializeUser(function(id, done) {
   logger.warn("DESERIALIZE USER");
-  //does not need projection
+  //we want mobile user to have access to their api token, but we don't want it to be select: true
   User.findOne({_id:id}).exec(function(err, user) {
     if(user) {
       return done(null, user);


### PR DESCRIPTION
issue discovered by austin in soflete. we want to store the actual user object in req.user, but previously it was only storing the projected object used to validate in passport. this meant that 1) user password fields were being returned to the front end, and b) any additional user fields, like "info" or "gender" were not being returned, despite being "select:true" in the model. fixed to now return the full user object (which doesn't return sensitive fields because they are "select:false" in the model.

also tweaked the mobile token stuff slightly as a result. we want it to be hidden by default, and only returned once on mobile login. pass this explicitly as a separate value in that method. will require very slight changed to the login method in future mobile projects. (NOT #38, although this will make that a little bit easier)

also added a readme link to the new-style google compute images.